### PR TITLE
Allow rendering a loader inside main sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/reusable-components",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Component library for code4ro",
   "keywords": [
     "code4ro",

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
@@ -25,6 +25,7 @@ type Props = {
   results?: ElectionResults | null;
   separator?: ReactNode;
   onScopeChange?: (scope: ElectionScopeIncomplete) => unknown;
+  loader?: ReactNode;
 };
 
 const defaultConstants = {
@@ -36,7 +37,7 @@ export const ElectionResultsSummarySection = themable<Props>(
   "ElectionResultsSummarySection",
   cssClasses,
   defaultConstants,
-)(({ classes, results, meta, api, scope, onScopeChange, constants, separator }) => {
+)(({ classes, results, meta, api, scope, onScopeChange, loader, constants, separator }) => {
   const involvesDiaspora = !!meta && electionTypeInvolvesDiaspora(meta.type);
 
   const [measureRef, { width }] = useDimensions();
@@ -87,11 +88,15 @@ export const ElectionResultsSummarySection = themable<Props>(
       {!completeness.complete && (
         <ElectionScopeIncompleteWarning className={classes.warning} completeness={completeness} page="results" />
       )}
-      {results == null && completeness.complete && (
-        <DivBodyHuge className={classes.warning}>
-          Nu există date despre prezența la vot pentru acest nivel de detaliu.
-        </DivBodyHuge>
-      )}
+      {results == null &&
+        completeness.complete &&
+        (loader ? (
+          loader
+        ) : (
+          <DivBodyHuge className={classes.warning}>
+            Nu există date despre prezența la vot pentru acest nivel de detaliu.
+          </DivBodyHuge>
+        ))}
       {results && <ElectionResultsStackedBar className={classes.stackedBar} results={results} />}
       <div style={{ width: "100%" }} ref={measureRef} />
       {results && !mobileMap && separator}

--- a/src/components/ElectionTurnoutSection/ElectionTurnoutSection.tsx
+++ b/src/components/ElectionTurnoutSection/ElectionTurnoutSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import {
   ElectionBallotMeta,
   ElectionScopeIncomplete,
@@ -23,6 +23,7 @@ type Props = {
   scope: ElectionScopeIncompleteResolved;
   onScopeChange?: (scope: ElectionScopeIncomplete) => unknown;
   turnout?: ElectionTurnout | null;
+  loader?: ReactNode;
 };
 
 const defaultConstants = {
@@ -35,7 +36,7 @@ export const ElectionTurnoutSection = themable<Props>(
   "ElectionTurnoutSection",
   cssClasses,
   defaultConstants,
-)(({ meta, scope, onScopeChange, turnout, classes, constants }) => {
+)(({ meta, scope, onScopeChange, turnout, loader, classes, constants }) => {
   const involvesDiaspora = !!meta && electionTypeInvolvesDiaspora(meta.type);
 
   const [measureRef, { width }] = useDimensions();
@@ -81,11 +82,15 @@ export const ElectionTurnoutSection = themable<Props>(
       {!completeness.complete && (
         <ElectionScopeIncompleteWarning className={classes.warning} completeness={completeness} page="turnout" />
       )}
-      {turnout == null && completeness.complete && (
-        <DivBodyHuge className={classes.warning}>
-          Nu există date despre prezența la vot pentru acest nivel de detaliu.
-        </DivBodyHuge>
-      )}
+      {turnout == null &&
+        completeness.complete &&
+        (loader ? (
+          loader
+        ) : (
+          <DivBodyHuge className={classes.warning}>
+            Nu există date despre prezența la vot pentru acest nivel de detaliu.
+          </DivBodyHuge>
+        ))}
       {turnout && turnout.eligibleVoters != null && (
         <ElectionTurnoutBars
           className={classes.percentageBars}


### PR DESCRIPTION

This paves way for a transition without re-rendering the map from incomplete scope
to complete.