### PR TITLE
Fix map zooming on the overlay bounds when loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/reusable-components",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/reusable-components",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Component library for code4ro",
   "keywords": [
     "code4ro",

--- a/src/components/ElectionMap/ElectionMap.tsx
+++ b/src/components/ElectionMap/ElectionMap.tsx
@@ -183,6 +183,7 @@ export const ElectionMap = themable<Props>(
                 overlayLoadTransform={
                   scope.type === "diaspora" || scope.type === "diaspora_country" ? bucharestCenteredWorldZoom : "bounds"
                 }
+                allowZoomAndPan={scope.type === "diaspora" || scope.type === "diaspora_country"}
                 overlayUrl={overlayUrl}
                 maskOverlayUrl={maskUrl}
                 selectedFeature={selectedFeature}

--- a/src/components/ElectionMap/ElectionMap.tsx
+++ b/src/components/ElectionMap/ElectionMap.tsx
@@ -187,6 +187,7 @@ export const ElectionMap = themable<Props>(
                 overlayUrl={overlayUrl}
                 maskOverlayUrl={maskUrl}
                 selectedFeature={selectedFeature}
+                centerOnSelectedFeatureBounds={scope.type === "diaspora_country"}
                 onFeatureSelect={onFeatureSelect}
                 getFeatureColor={getFeatureColor}
                 renderFeatureTooltip={renderFeatureTooltip}

--- a/src/components/ElectionMap/ElectionMap.tsx
+++ b/src/components/ElectionMap/ElectionMap.tsx
@@ -3,7 +3,7 @@ import { ElectionMapScope, ElectionMapWinner, ElectionScopeIncomplete } from "..
 import { mergeClasses, themable } from "../../hooks/theme";
 import RomaniaMap from "../../assets/romania-map.svg";
 import { useDimensions } from "../../hooks/useDimensions";
-import { HereMap, romaniaMapBounds, worldMapBounds } from "../HereMap/HereMap";
+import { bucharestCenteredWorldZoom, HereMap, romaniaMapBounds } from "../HereMap/HereMap";
 import { electionMapOverlayUrl } from "../../constants/servers";
 import cssClasses from "./ElectionMap.module.scss";
 import { ElectionMapAPI } from "../../util/electionApi";
@@ -175,9 +175,13 @@ export const ElectionMap = themable<Props>(
                 className={classes.hereMap}
                 width={width}
                 height={height}
-                scopeType={scope.type}
-                initialBounds={
-                  scope.type === "diaspora" || scope.type === "diaspora_country" ? worldMapBounds : romaniaMapBounds
+                initialTransform={
+                  scope.type === "diaspora" || scope.type === "diaspora_country"
+                    ? bucharestCenteredWorldZoom
+                    : romaniaMapBounds
+                }
+                overlayLoadTransform={
+                  scope.type === "diaspora" || scope.type === "diaspora_country" ? bucharestCenteredWorldZoom : "bounds"
                 }
                 overlayUrl={overlayUrl}
                 maskOverlayUrl={maskUrl}

--- a/src/components/HereMap/HereMap.module.scss
+++ b/src/components/HereMap/HereMap.module.scss
@@ -16,7 +16,7 @@
   left: 0;
   top: 0;
   transform: translate(-50%, calc(-100% - 8px));
-  font-size: 12rem / 16;
+  font-size: 1rem;
   color: #fff;
   border-radius: 0.25rem;
   padding: 0.5rem;

--- a/src/components/HereMap/HereMap.module.scss
+++ b/src/components/HereMap/HereMap.module.scss
@@ -2,6 +2,13 @@
 
 .root {
   position: relative;
+  -webkit-touch-callout:none;
+  -webkit-user-select:none;
+  -khtml-user-select:none;
+  -moz-user-select:none;
+  -ms-user-select:none;
+  user-select:none;
+  -webkit-tap-highlight-color:rgba(0,0,0,0);
 }
 
 .tooltip {

--- a/src/components/HereMap/HereMap.tsx
+++ b/src/components/HereMap/HereMap.tsx
@@ -150,6 +150,15 @@ const stylesFromColor = (H: HereMapsAPI, color: string, featureSelectedDarken: n
   };
 };
 
+const setTooltipPosition = (self: InstanceVars, x: number, y: number) => {
+  self.tooltipLeft = x;
+  self.tooltipTop = y;
+  if (self.tooltipEl) {
+    self.tooltipEl.style.left = `${x}px`;
+    self.tooltipEl.style.top = `${y}px`;
+  }
+};
+
 export const HereMap = themable<Props>(
   "HereMap",
   cssClasses,
@@ -255,13 +264,9 @@ export const HereMap = themable<Props>(
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       hMap.addEventListener("pointermove", (evt: any) => {
-        const { offsetX = 0, offsetY = 0 } = evt.originalEvent;
-        self.tooltipLeft = offsetX;
-        self.tooltipTop = offsetY;
-        if (self.tooltipEl) {
-          self.tooltipEl.style.left = `${offsetX}px`;
-          self.tooltipEl.style.top = `${offsetY}px`;
-        }
+        const { offsetX = 0, offsetY = 0, pointerType } = evt.originalEvent;
+        if (pointerType === "touch") return;
+        setTooltipPosition(self, offsetX, offsetY);
       });
 
       return () => {
@@ -405,6 +410,12 @@ export const HereMap = themable<Props>(
           if (id == null) return;
           if (self.hoveredFeature?.id !== id) setHoveredFeature(id, data);
           self.updateFeatureStyle(mapObject, id === self.selectedFeature, true);
+
+          if ((evt as any)?.originalEvent?.pointerType === "touch") {
+            const bounds = mapObject.getBoundingBox();
+            const { x, y } = map.geoToScreen({ lat: bounds.getTop(), lng: bounds.getCenter().lng });
+            setTooltipPosition(self, x, y - 5);
+          }
         }
       };
 


### PR DESCRIPTION
* Retain the new fixed-zoomlevel behaviour for diaspora, whilst still keeping the "zoom to overlay bounds" behaviour when the overlay changes (for example, transitions from county to locality scopes).

* Move scope-specific logic out of HereMaps and into ElectionMap to keep concerns separated.

* Prevent zooming on non-diaspora scopes.

* Zoom on currently selected diaspora country.

* Improve tooltip behaviour on touch devices.

