### PR TITLE
Mark election live if any of its ballots is live

### DIFF
--- a/src/components/ElectionTimeline/ElectionTimeline.tsx
+++ b/src/components/ElectionTimeline/ElectionTimeline.tsx
@@ -47,11 +47,12 @@ export const ElectionTimeline = themable<Props>(
       const { electionId } = meta;
       let election = electionsById.get(electionId);
       if (!election) {
-        election = { electionId, title: meta.title, live: !!meta.live, ballots: [] };
+        election = { electionId, title: meta.title, live: false, ballots: [] };
         currentYear.elections.push(election);
         electionsById.set(electionId, election);
       }
 
+      election.live = election.live || !!meta.live;
       election.ballots.push(meta);
     });
 


### PR DESCRIPTION
Needed for round 2 elections.

The previous behaviour was marking the election as live in the timeline only if its first ballot was live.