### PR TITLE
Added hover titles for when the table is too small

### DIFF
--- a/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.tsx
+++ b/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.tsx
@@ -13,8 +13,12 @@ type Props = {
   table: { tHead1: string; tHead2: string; tHead3: string; tHead4: string; tHead5: string };
 };
 
+type CellProps = {
+  title?: string;
+};
+
 const THeadRow = makeTypographyComponent("th", "label");
-const TCell = makeTypographyComponent("td", "bodyMedium");
+const TCell = makeTypographyComponent<CellProps>("td", "bodyMedium");
 
 export const ElectionResultsSummaryTable = themable<Props>(
   "ElectionResultsSummaryTable",
@@ -57,7 +61,7 @@ export const ElectionResultsSummaryTable = themable<Props>(
           <tbody>
             {results.candidates.map((candidate, index) => (
               <tr key={index}>
-                <TCell className={classes.name}>
+                <TCell className={classes.name} title={candidate.shortName || candidate.name}>
                   <ColoredSquare color={electionCandidateColor(candidate)} className={classes.square} />
                   {candidate.shortName || candidate.name}
                 </TCell>


### PR DESCRIPTION
### What does it fix?

Closes https://github.com/code4romania/rezultate-vot-client/issues/78

Adds a hover hint for the election summary results table so if the candidate/party name doesn't fit the table cell it's in, you still can see the name by hovering the table cell.