### PR TITLE
Added the ability to show dicrete values in votes stackbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/reusable-components",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Component library for code4ro",
   "keywords": [
     "code4ro",

--- a/src/components/ElectionMap/ElectionMap.tsx
+++ b/src/components/ElectionMap/ElectionMap.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, PropsWithChildren, useContext, useCallback, useMemo } from "react";
-import { ElectionMapScope, ElectionMapWinner, ElectionScopeIncomplete } from "../../types/Election";
+import { ElectionMapScope, ElectionMapWinner, ElectionScopeIncomplete, ElectionType } from "../../types/Election";
 import { mergeClasses, themable } from "../../hooks/theme";
 import RomaniaMap from "../../assets/romania-map.svg";
 import { useDimensions } from "../../hooks/useDimensions";
@@ -18,6 +18,7 @@ type Props = PropsWithChildren<{
   maxHeight?: number;
   selectedColor?: string;
   defaultColor?: string;
+  electionType?: ElectionType;
 
   api?: ElectionMapAPI;
   ballotId?: number | null;
@@ -41,12 +42,16 @@ export const ElectionMap = themable<Props>(
     children,
     selectedColor,
     defaultColor,
+    electionType,
     api,
     ballotId,
   }) => {
     const [ref, { width = 0 }] = useDimensions();
 
-    const showsSimpleMap = scope.type === "national";
+    const showsSimpleMap =
+      scope.type === "national" &&
+      ["referendum", "president", "senate", "house", "european_parliament"].includes(electionType);
+
     const ar = aspectRatio ?? defaultAspectRatio;
     let height = Math.min(maxHeight, width / ar);
     if (!Number.isFinite(height)) {

--- a/src/components/ElectionMap/ElectionMap.tsx
+++ b/src/components/ElectionMap/ElectionMap.tsx
@@ -101,7 +101,7 @@ export const ElectionMap = themable<Props>(
         return [{ type: "national" }, scope.countyId ?? null, (countyId) => ({ ...scope, countyId })];
       }
 
-      if (scope.type === "county") {
+      if (scope.type === "county" && scope.countyId !== null) {
         return [{ type: "county", countyId: scope.countyId }, null, (localityId) => ({ ...scope, localityId })];
       }
 

--- a/src/components/ElectionMap/ElectionMap.tsx
+++ b/src/components/ElectionMap/ElectionMap.tsx
@@ -50,7 +50,8 @@ export const ElectionMap = themable<Props>(
 
     const showsSimpleMap =
       scope.type === "national" &&
-      ["referendum", "president", "senate", "house", "european_parliament"].includes(electionType);
+      (electionType === undefined ||
+        ["referendum", "president", "senate", "house", "european_parliament"].includes(electionType));
 
     const ar = aspectRatio ?? defaultAspectRatio;
     let height = Math.min(maxHeight, width / ar);

--- a/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.stories.tsx
+++ b/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.stories.tsx
@@ -2,99 +2,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import React from "react";
-import { mockResults } from "../../util/mocks";
+import { mockResults, mockCountyCouncilResults } from "../../util/mocks";
 import { ElectionResultsStackedBar } from "./ElectionResultsStackedBar";
-
-const nationalResultsExample = {
-  eligibleVoters: 18466219,
-  totalVotes: 8419716,
-  validVotes: 7937514,
-  nullVotes: 482202,
-  totalSeats: 0,
-  candidates: [
-    {
-      name: "Partidul Social Democrat",
-      partyColor: "#FF0000",
-      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-      votes: 16,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "Partidul Național Liberal",
-      partyColor: "#F8DD1B",
-      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-      votes: 15,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
-      partyColor: "#007300",
-      partyLogo:
-        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
-      votes: 4,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "ALIANȚA ELECTORALĂ ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020",
-      shortName: "A. ELECTORALĂ PENTRU MODERNIZAREA NEAMȚULUI 2020",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "ALIANȚA PNL USR PLUS",
-      shortName: "A. PNL USR PLUS",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD",
-      shortName: "A. NĂSĂUD",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "INDEPENDENT",
-      shortName: "INDEPENDENT",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "ALIANTA ELECTORALA PSD+ALDE DOLJ",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name: "ALIANȚA PSD-PRO BUZĂU",
-      shortName: "A. PRO BUZĂU",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-    {
-      name:
-        "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
-      shortName: "A.  UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
-      partyColor: "#808080",
-      votes: 1,
-      seats: 0,
-      totalSeats: 0,
-    },
-  ],
-};
 
 export default {
   title: "Election results stacked bar",
@@ -118,7 +27,7 @@ export const ExampleWithDiscreteValues = (args: any) => {
 };
 
 ExampleWithDiscreteValues.args = {
-  results: nationalResultsExample,
+  results: mockCountyCouncilResults,
   displayPercentages: false,
 };
 

--- a/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.stories.tsx
+++ b/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.stories.tsx
@@ -5,6 +5,97 @@ import React from "react";
 import { mockResults } from "../../util/mocks";
 import { ElectionResultsStackedBar } from "./ElectionResultsStackedBar";
 
+const nationalResultsExample = {
+  eligibleVoters: 18466219,
+  totalVotes: 8419716,
+  validVotes: 7937514,
+  nullVotes: 482202,
+  totalSeats: 0,
+  candidates: [
+    {
+      name: "Partidul Social Democrat",
+      partyColor: "#FF0000",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+      votes: 16,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "Partidul Național Liberal",
+      partyColor: "#F8DD1B",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+      votes: 15,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+      partyColor: "#007300",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+      votes: 4,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA ELECTORALĂ ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020",
+      shortName: "A. ELECTORALĂ PENTRU MODERNIZAREA NEAMȚULUI 2020",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA PNL USR PLUS",
+      shortName: "A. PNL USR PLUS",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD",
+      shortName: "A. NĂSĂUD",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "INDEPENDENT",
+      shortName: "INDEPENDENT",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANTA ELECTORALA PSD+ALDE DOLJ",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA PSD-PRO BUZĂU",
+      shortName: "A. PRO BUZĂU",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name:
+        "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
+      shortName: "A.  UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+  ],
+};
+
 export default {
   title: "Election results stacked bar",
   component: ElectionResultsStackedBar,
@@ -19,5 +110,18 @@ SimpleExample.args = {
 };
 
 SimpleExample.argTypes = {
+  results: { control: "object" },
+};
+
+export const ExampleWithDiscreteValues = (args: any) => {
+  return <ElectionResultsStackedBar {...args} />;
+};
+
+ExampleWithDiscreteValues.args = {
+  results: nationalResultsExample,
+  displayPercentages: false,
+};
+
+ExampleWithDiscreteValues.argTypes = {
   results: { control: "object" },
 };

--- a/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.tsx
+++ b/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.tsx
@@ -11,6 +11,7 @@ import cssClasses from "./ElectionResultsStackedBar.module.scss";
 type Props = {
   results: ElectionResults;
   meta?: ElectionBallotMeta | null;
+  displayPercentages?: boolean;
 };
 
 const defaultConstants = {
@@ -25,9 +26,11 @@ export const ElectionResultsStackedBar = themable<Props>(
   "ElectionResultsStackedBar",
   cssClasses,
   defaultConstants,
-)(({ classes, results, constants, meta }) => {
+)(({ classes, results, constants, meta, displayPercentages }) => {
   const { candidates } = results;
   const { neutralColor, maxStackedBarItems, breakpoint1, breakpoint2, breakpoint3 } = constants;
+
+  const showPercentages = displayPercentages ?? true;
 
   const [stackedBarItems, legendItems] = useMemo(() => {
     const items: (HorizontalStackedBarItem & {
@@ -37,7 +40,10 @@ export const ElectionResultsStackedBar = themable<Props>(
       index: number;
     })[] = [];
 
-    const percentageBasis = meta?.type === "referendum" ? results.eligibleVoters ?? 0 : results.validVotes;
+    const sumOfVotes = candidates.reduce((crtValue, candidate) => crtValue + candidate.votes, 0);
+
+    const percentageBasis =
+      meta?.type === "referendum" ? results.eligibleVoters ?? 0 : showPercentages ? results.validVotes : sumOfVotes;
 
     const stackedBarCount = candidates.length === maxStackedBarItems + 1 ? maxStackedBarItems + 1 : maxStackedBarItems;
     for (let i = 0; i < stackedBarCount; i++) {
@@ -94,7 +100,8 @@ export const ElectionResultsStackedBar = themable<Props>(
                 key={item.index}
                 name={item.name}
                 color={item.color}
-                percentage={item.percent}
+                value={showPercentages ? item.percent : item.value}
+                isPercentage={showPercentages}
                 iconUrl={(width >= breakpoint1 || item.index < 2) && width >= breakpoint3 ? item.logo : undefined}
                 rightAligned={index === stackedBarItems.length - 1}
               />
@@ -110,7 +117,7 @@ export const ElectionResultsStackedBar = themable<Props>(
             name={item.name}
             color={item.color}
             votes={item.value}
-            percentage={item.percent}
+            percentage={showPercentages ? item.percent : undefined}
           />
         ))}
       </div>

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
@@ -6,6 +6,7 @@ import {
   mockCountyCouncilElectionMeta,
   mockCountyCouncilResults,
   mockDiasporaElectionScope,
+  mockElectionAPI,
   mockLocalCouncilElectionMeta,
   mockLocalityElectionScope,
   mockNationalElectionScope,
@@ -45,6 +46,7 @@ export const CountyCouncilElection = () => {
       scope={mockNationalElectionScope}
       meta={mockCountyCouncilElectionMeta}
       results={mockCountyCouncilResults}
+      api={mockElectionAPI}
     />
   );
 };

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import { ElectionScopeIncompleteResolved } from "../../types/Election";
 import {
+  mockCountyCouncilElectionMeta,
+  mockCountyCouncilResults,
   mockDiasporaElectionScope,
   mockLocalCouncilElectionMeta,
   mockLocalityElectionScope,
@@ -33,6 +35,16 @@ export const LocalCouncilElection = () => {
       scope={mockNationalElectionScope}
       meta={mockLocalCouncilElectionMeta}
       results={mockResults}
+    />
+  );
+};
+
+export const CountyCouncilElection = () => {
+  return (
+    <ElectionResultsSummarySection
+      scope={mockNationalElectionScope}
+      meta={mockCountyCouncilElectionMeta}
+      results={mockCountyCouncilResults}
     />
   );
 };

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
@@ -5,10 +5,12 @@ import { ElectionScopeIncompleteResolved } from "../../types/Election";
 import {
   mockCountyCouncilElectionMeta,
   mockCountyCouncilResults,
+  mockCountyElectionScope,
   mockDiasporaElectionScope,
   mockElectionAPI,
   mockLocalCouncilElectionMeta,
   mockLocalityElectionScope,
+  mockMayorResults,
   mockNationalElectionScope,
   mockPresidentialElectionMeta,
   mockResults,
@@ -33,9 +35,10 @@ export const PresidentialElection = () => {
 export const LocalCouncilElection = () => {
   return (
     <ElectionResultsSummarySection
-      scope={mockNationalElectionScope}
+      scope={mockCountyElectionScope}
       meta={mockLocalCouncilElectionMeta}
-      results={mockResults}
+      results={mockMayorResults}
+      api={mockElectionAPI}
     />
   );
 };

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
@@ -9,7 +9,9 @@ import {
   mockDiasporaElectionScope,
   mockElectionAPI,
   mockLocalCouncilElectionMeta,
+  mockLocalCouncilResults,
   mockLocalityElectionScope,
+  mockMayorElectionMeta,
   mockMayorResults,
   mockNationalElectionScope,
   mockPresidentialElectionMeta,
@@ -32,12 +34,23 @@ export const PresidentialElection = () => {
   );
 };
 
+export const MayorPerCountyElection = () => {
+  return (
+    <ElectionResultsSummarySection
+      scope={mockCountyElectionScope}
+      meta={mockMayorElectionMeta}
+      results={mockMayorResults}
+      api={mockElectionAPI}
+    />
+  );
+};
+
 export const LocalCouncilElection = () => {
   return (
     <ElectionResultsSummarySection
       scope={mockCountyElectionScope}
       meta={mockLocalCouncilElectionMeta}
-      results={mockMayorResults}
+      results={mockLocalCouncilResults}
       api={mockElectionAPI}
     />
   );

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
@@ -125,6 +125,7 @@ export const ElectionResultsSummarySection = themable<Props>(
               meta={meta}
               results={results}
               headers={tableHeaders}
+              displayVotesAsSeats={!displayPercentages}
             />
           )}
           {map}

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
@@ -60,6 +60,7 @@ export const ElectionResultsSummarySection = themable<Props>(
   const map = width != null && (
     <ElectionMap
       scope={scope}
+      electionType={meta?.type}
       onScopeChange={onScopeChange}
       className={classes.map}
       selectedColor={topCandidate && electionCandidateColor(topCandidate)}

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react";
 import {
   ElectionBallotMeta,
   ElectionResults,
+  electionResultsShouldShowAsPercentages,
   ElectionScopeIncomplete,
   ElectionScopeIncompleteResolved,
   electionScopeIsComplete,
@@ -44,6 +45,8 @@ export const ElectionResultsSummarySection = themable<Props>(
   const [measureRef, { width }] = useDimensions();
 
   const completeness = electionScopeIsComplete(scope);
+
+  const displayPercentages = scope && meta ? electionResultsShouldShowAsPercentages(scope, meta) : true;
 
   const topCandidate = results?.candidates && results.candidates[0];
   const percentage = formatPercentage(
@@ -104,7 +107,14 @@ export const ElectionResultsSummarySection = themable<Props>(
             fie câștigătorii pentru această unitate au fost aleși în primul tur de scrutin.
           </DivBodyHuge>
         ))}
-      {results && <ElectionResultsStackedBar className={classes.stackedBar} results={results} meta={meta} />}
+      {results && (
+        <ElectionResultsStackedBar
+          className={classes.stackedBar}
+          results={results}
+          meta={meta}
+          displayPercentages={displayPercentages}
+        />
+      )}
       <div style={{ width: "100%" }} ref={measureRef} />
       {results && !mobileMap && separator}
       {!mobileMap && (

--- a/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.stories.tsx
+++ b/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.stories.tsx
@@ -2,7 +2,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import React from "react";
-import { mockLocalCouncilElectionMeta, mockResults } from "../../util/mocks";
+import {
+  mockCountyCouncilElectionMeta,
+  mockCountyCouncilResults,
+  mockLocalCouncilElectionMeta,
+  mockResults,
+} from "../../util/mocks";
 import { ElectionResultsSummaryTable } from "./ElectionResultsSummaryTable";
 
 export default {
@@ -21,6 +26,22 @@ SimpleExample.args = {
 };
 
 SimpleExample.argTypes = {
+  results: { control: "object" },
+  header: { control: "object" },
+};
+
+export const ExampleWithVotesAsSeats = (args: any) => {
+  return <ElectionResultsSummaryTable {...args} />;
+};
+
+ExampleWithVotesAsSeats.args = {
+  meta: mockCountyCouncilElectionMeta,
+  results: mockCountyCouncilResults,
+  header: { candidate: "Partid", seats: "Mand.", votes: "Voturi", percentage: "%" },
+  displayVotesAsSeats: true,
+};
+
+ExampleWithVotesAsSeats.argTypes = {
   results: { control: "object" },
   header: { control: "object" },
 };

--- a/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.tsx
+++ b/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { electionHasSeats, ElectionBallotMeta, ElectionResults, ElectionResultsCandidate } from "../../types/Election";
+import {
+  electionHasSeats,
+  ElectionBallotMeta,
+  ElectionResults,
+  ElectionResultsCandidate,
+  ElectionType,
+} from "../../types/Election";
 import { ClassNames, themable } from "../../hooks/theme";
 import { DivBody, Heading3, makeTypographyComponent } from "../Typography/Typography";
 import { lightFormat, parseISO } from "date-fns";
@@ -54,11 +60,12 @@ const headerRowForVotesWithSeats = function (
   );
 };
 
-const headerRowForVotesAsSeatsWon = function () {
+const headerRowForVotesAsSeatsWon = function (type: ElectionType) {
+  const placesWonTitle = type === "mayor" ? "Nr. Primari" : type === "county_council_president" ? "Nr. Presedinti" : "";
   return (
     <tr>
       <THeadRow>Partid</THeadRow>
-      <THeadRow>Mandate</THeadRow>
+      <THeadRow>{placesWonTitle}</THeadRow>
     </tr>
   );
 };
@@ -126,7 +133,7 @@ export const ElectionResultsSummaryTable = themable<Props>(
         <table className={classes.table}>
           <thead>
             {displayVotesAsSeats ?? false
-              ? headerRowForVotesAsSeatsWon()
+              ? headerRowForVotesAsSeatsWon(meta.type)
               : headerRowForVotesWithSeats(headers, isReferendum, hasSeats, classes)}
           </thead>
           <tbody>

--- a/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.tsx
+++ b/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { electionHasSeats, ElectionBallotMeta, ElectionResults } from "../../types/Election";
-import { themable } from "../../hooks/theme";
+import { electionHasSeats, ElectionBallotMeta, ElectionResults, ElectionResultsCandidate } from "../../types/Election";
+import { ClassNames, themable } from "../../hooks/theme";
 import { DivBody, Heading3, makeTypographyComponent } from "../Typography/Typography";
 import { lightFormat, parseISO } from "date-fns";
 import { electionCandidateColor, formatGroupedNumber, formatPercentage, fractionOf } from "../../util/format";
@@ -19,6 +19,7 @@ type Props = {
   meta: ElectionBallotMeta;
   results: ElectionResults;
   headers?: ElectionResultsSummaryTableHeaders;
+  displayVotesAsSeats?: boolean;
 };
 
 type CellProps = {
@@ -28,10 +29,78 @@ type CellProps = {
 const THeadRow = makeTypographyComponent("th", "label");
 const TCell = makeTypographyComponent<CellProps>("td", "bodyMedium");
 
+const headerRowForVotesWithSeats = function (
+  headers:
+    | {
+        candidate?: string;
+        seats?: string;
+        votes?: string;
+        percentage?: string;
+        bar?: string;
+      }
+    | undefined,
+  isReferendum: boolean,
+  hasSeats: boolean,
+  classes: ClassNames,
+) {
+  return (
+    <tr>
+      <THeadRow>{headers?.candidate ?? (isReferendum ? "Opțiune" : "Partid")}</THeadRow>
+      {hasSeats && <THeadRow>{headers?.seats ?? "Mand."}</THeadRow>}
+      <THeadRow>{headers?.votes ?? "Voturi"}</THeadRow>
+      <THeadRow className={classes.percentage}>{headers?.percentage ?? "%"}</THeadRow>
+      <THeadRow>{headers?.bar ?? ""}</THeadRow>
+    </tr>
+  );
+};
+
+const headerRowForVotesAsSeatsWon = function () {
+  return (
+    <tr>
+      <THeadRow>Partid</THeadRow>
+      <THeadRow>Mandate</THeadRow>
+    </tr>
+  );
+};
+
+const getRowWithVotesAndSeatsForCandidate = function (
+  hasSeats: boolean,
+  candidate: ElectionResultsCandidate,
+  classes: ClassNames,
+  percentages: number[],
+  index: number,
+  maxFraction: number,
+) {
+  return (
+    <>
+      {hasSeats && <TCell>{candidate.seats != null && formatGroupedNumber(candidate.seats)}</TCell>}
+      <TCell>{formatGroupedNumber(candidate.votes)}</TCell>
+      <TCell className={classes.percentage}>{formatPercentage(percentages[index])}</TCell>
+      <td className={classes.barContainer}>
+        <div
+          className={classes.bar}
+          style={{
+            width: `${100 * fractionOf(percentages[index], maxFraction)}%`,
+            backgroundColor: electionCandidateColor(candidate),
+          }}
+        />
+      </td>
+    </>
+  );
+};
+
+const getRowWithVotesAsSeatsForCandidate = function (candidate: ElectionResultsCandidate) {
+  return (
+    <>
+      <TCell>{formatGroupedNumber(candidate.votes)}</TCell>
+    </>
+  );
+};
+
 export const ElectionResultsSummaryTable = themable<Props>(
   "ElectionResultsSummaryTable",
   cssClasses,
-)(({ classes, results, meta, headers }) => {
+)(({ classes, results, meta, headers, displayVotesAsSeats }) => {
   const hasSeats = electionHasSeats(meta.type, results);
   const isReferendum = meta.type === "referendum";
   const percentageBasis = isReferendum ? results.eligibleVoters ?? 0 : results.validVotes;
@@ -56,13 +125,9 @@ export const ElectionResultsSummaryTable = themable<Props>(
       <div className={classes.tableContainer}>
         <table className={classes.table}>
           <thead>
-            <tr>
-              <THeadRow>{headers?.candidate ?? (isReferendum ? "Opțiune" : "Partid")}</THeadRow>
-              {hasSeats && <THeadRow>{headers?.seats ?? "Mand."}</THeadRow>}
-              <THeadRow>{headers?.votes ?? "Voturi"}</THeadRow>
-              <THeadRow className={classes.percentage}>{headers?.percentage ?? "%"}</THeadRow>
-              <THeadRow>{headers?.bar ?? ""}</THeadRow>
-            </tr>
+            {displayVotesAsSeats ?? false
+              ? headerRowForVotesAsSeatsWon()
+              : headerRowForVotesWithSeats(headers, isReferendum, hasSeats, classes)}
           </thead>
           <tbody>
             {results.candidates.map((candidate, index) => (
@@ -71,18 +136,9 @@ export const ElectionResultsSummaryTable = themable<Props>(
                   <ColoredSquare color={electionCandidateColor(candidate)} className={classes.square} />
                   {candidate.shortName || candidate.name}
                 </TCell>
-                {hasSeats && <TCell>{candidate.seats != null && formatGroupedNumber(candidate.seats)}</TCell>}
-                <TCell>{formatGroupedNumber(candidate.votes)}</TCell>
-                <TCell className={classes.percentage}>{formatPercentage(percentages[index])}</TCell>
-                <td className={classes.barContainer}>
-                  <div
-                    className={classes.bar}
-                    style={{
-                      width: `${100 * fractionOf(percentages[index], maxFraction)}%`,
-                      backgroundColor: electionCandidateColor(candidate),
-                    }}
-                  />
-                </td>
+                {displayVotesAsSeats ?? false
+                  ? getRowWithVotesAsSeatsForCandidate(candidate)
+                  : getRowWithVotesAndSeatsForCandidate(hasSeats, candidate, classes, percentages, index, maxFraction)}
               </tr>
             ))}
           </tbody>

--- a/src/components/PartyResultCard/PartyResultCard.tsx
+++ b/src/components/PartyResultCard/PartyResultCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { mergeClasses, themable } from "../../hooks/theme";
-import { formatPercentage } from "../../util/format";
+import { formatGroupedNumber, formatPercentage } from "../../util/format";
 import { DivBodyMedium, DivHeading1 } from "../Typography/Typography";
 import { ColoredSquare } from "../ColoredSquare/ColoredSquare";
 import cssClasses from "./PartyResultCard.module.scss";
@@ -8,7 +8,8 @@ import cssClasses from "./PartyResultCard.module.scss";
 type Props = {
   name: string;
   color: string;
-  percentage: number;
+  value: number;
+  isPercentage?: boolean;
   rightAligned?: boolean;
   iconUrl?: string;
 };
@@ -16,7 +17,7 @@ type Props = {
 export const PartyResultCard = themable<Props>(
   "PartyResultCard",
   cssClasses,
-)(({ classes, name, color, percentage, rightAligned, iconUrl }) => (
+)(({ classes, name, color, value, rightAligned, iconUrl, isPercentage }) => (
   <div className={mergeClasses(classes.root, rightAligned && classes.rightAlign)}>
     {iconUrl && <img className={classes.icon} src={iconUrl} alt={name} />}
     <div className={classes.column}>
@@ -24,7 +25,9 @@ export const PartyResultCard = themable<Props>(
         <ColoredSquare className={classes.square} color={color} />
         <div className={classes.name}>{name}</div>
       </DivBodyMedium>
-      <DivHeading1 className={classes.percentage}>{formatPercentage(percentage)}</DivHeading1>
+      <DivHeading1 className={classes.percentage}>
+        {isPercentage ?? true ? formatPercentage(value) : formatGroupedNumber(value)}
+      </DivHeading1>
     </div>
   </div>
 ));

--- a/src/types/Election.ts
+++ b/src/types/Election.ts
@@ -34,10 +34,7 @@ export const electionResultsShouldShowAsPercentages = (
   if (
     (scope.type === "national" && meta.type === "mayor") ||
     (scope.type === "county" && meta.type === "mayor" && scope.countyId !== 12913) ||
-    (scope.type === "national" && meta.type === "county_council_president") ||
-    (scope.type === "county" && meta.type === "local_council") ||
-    (scope.type === "national" && meta.type === "local_council") ||
-    (scope.type === "national" && meta.type === "county_council")
+    (scope.type === "national" && meta.type === "county_council_president")
   ) {
     return false;
   }

--- a/src/types/Election.ts
+++ b/src/types/Election.ts
@@ -27,6 +27,24 @@ export const electionScopeIsComplete = (scope: ElectionScopeIncomplete): Electio
   };
 };
 
+export const electionResultsShouldShowAsPercentages = (
+  scope: ElectionScopeIncomplete,
+  meta: ElectionBallotMeta,
+): boolean => {
+  if (
+    (scope.type === "national" && meta.type === "mayor") ||
+    (scope.type === "county" && meta.type === "mayor" && scope.countyId !== 12913) ||
+    (scope.type === "national" && meta.type === "county_council_president") ||
+    (scope.type === "county" && meta.type === "local_council") ||
+    (scope.type === "national" && meta.type === "local_council") ||
+    (scope.type === "national" && meta.type === "county_council")
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 export type ElectionScopeNames = {
   countyName?: string | null;
   countryName?: string | null;

--- a/src/util/mocks.ts
+++ b/src/util/mocks.ts
@@ -55,7 +55,6 @@ export const mockCountyCouncilElectionMeta: ElectionBallotMeta = {
   electionId: 3,
 };
 
-
 export const mockPresidentialElectionTurnout: ElectionTurnout = {
   eligibleVoters: 18217411,
   totalVotes: 9086696,
@@ -281,7 +280,6 @@ export const mockCountyCouncilResults = {
     },
   ],
 };
-
 
 export const mockElectionList = [
   {

--- a/src/util/mocks.ts
+++ b/src/util/mocks.ts
@@ -46,8 +46,17 @@ export const mockLocalCouncilElectionMeta: ElectionBallotMeta = {
   electionId: 2,
 };
 
+export const mockMayorElectionMeta: ElectionBallotMeta = {
+  type: "mayor",
+  date: "2016-06-05",
+  title: "Alegeri locale",
+  ballot: "Consiliul Local",
+  ballotId: 4,
+  electionId: 4,
+};
+
 export const mockCountyCouncilElectionMeta: ElectionBallotMeta = {
-  type: "county_council",
+  type: "county_council_president",
   date: "2016-06-05",
   title: "Alegeri Locale",
   ballot: "Consiliul judetean",
@@ -186,6 +195,70 @@ export const mockResults: ElectionResults = {
       name: "Dummy 8",
       shortName: "DUM8",
       votes: 1063331,
+    },
+  ],
+};
+
+export const mockLocalCouncilResults = {
+  eligibleVoters: 313454,
+  totalVotes: 155683,
+  validVotes: 150100,
+  nullVotes: 5583,
+  totalSeats: 0,
+  candidates: [
+    {
+      name: "Partidul Național Liberal",
+      partyColor: "#F8DD1B",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+      votes: 63835,
+      seats: 422,
+      totalSeats: 422,
+    },
+    {
+      name: "Partidul Social Democrat",
+      partyColor: "#FF0000",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+      votes: 5379,
+      seats: 55,
+      totalSeats: 55,
+    },
+    {
+      name: "Alianța pentru Unirea Românilor",
+      shortName: "A. pentru Unirea Românilor",
+      partyColor: "#660066",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Alian%C8%9Ba+pentru+Unirea+Rom%C3%A2nilor.jpg",
+      votes: 869,
+      seats: 7,
+      totalSeats: 7,
+    },
+    {
+      name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+      partyColor: "#007300",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+      votes: 825,
+      seats: 11,
+      totalSeats: 11,
+    },
+    {
+      name: "Alianța Liberalilor și Democraților",
+      shortName: "A. Liberalilor și Democraților",
+      partyColor: "#B2B200",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Alian%C8%9Ba+Liberalilor+%C8%99i+Democra%C8%9Bilor.jpg",
+      votes: 528,
+      seats: 5,
+      totalSeats: 5,
+    },
+    {
+      name: "Partidul Miscarea Populară",
+      partyColor: "#000099",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Miscarea+Popular%C4%83.jpg",
+      votes: 161,
+      seats: 6,
+      totalSeats: 6,
     },
   ],
 };

--- a/src/util/mocks.ts
+++ b/src/util/mocks.ts
@@ -46,6 +46,16 @@ export const mockLocalCouncilElectionMeta: ElectionBallotMeta = {
   electionId: 2,
 };
 
+export const mockCountyCouncilElectionMeta: ElectionBallotMeta = {
+  type: "county_council",
+  date: "2016-06-05",
+  title: "Alegeri Locale",
+  ballot: "Consiliul judetean",
+  ballotId: 3,
+  electionId: 3,
+};
+
+
 export const mockPresidentialElectionTurnout: ElectionTurnout = {
   eligibleVoters: 18217411,
   totalVotes: 9086696,
@@ -180,6 +190,98 @@ export const mockResults: ElectionResults = {
     },
   ],
 };
+
+export const mockCountyCouncilResults = {
+  eligibleVoters: 18466219,
+  totalVotes: 8419716,
+  validVotes: 7937514,
+  nullVotes: 482202,
+  totalSeats: 0,
+  candidates: [
+    {
+      name: "Partidul Social Democrat",
+      partyColor: "#FF0000",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+      votes: 16,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "Partidul Național Liberal",
+      partyColor: "#F8DD1B",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+      votes: 15,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+      partyColor: "#007300",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+      votes: 4,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA ELECTORALĂ ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020",
+      shortName: "A. ELECTORALĂ PENTRU MODERNIZAREA NEAMȚULUI 2020",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA PNL USR PLUS",
+      shortName: "A. PNL USR PLUS",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD",
+      shortName: "A. NĂSĂUD",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "INDEPENDENT",
+      shortName: "INDEPENDENT",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANTA ELECTORALA PSD+ALDE DOLJ",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "ALIANȚA PSD-PRO BUZĂU",
+      shortName: "A. PRO BUZĂU",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name:
+        "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
+      shortName: "A.  UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
+      partyColor: "#808080",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+  ],
+};
+
 
 export const mockElectionList = [
   {

--- a/src/util/mocks.ts
+++ b/src/util/mocks.ts
@@ -9,7 +9,7 @@ import {
   ElectionScopeResolved,
   ElectionTurnout,
 } from "../types/Election";
-import { mockFetch, APIMockHandler } from "./api";
+import { APIMockHandler, mockFetch } from "./api";
 import { makeElectionApi } from "./electionApi";
 
 export const mockNationalElectionScope: ElectionScopeResolved = { type: "national" };
@@ -927,6 +927,680 @@ export const mockElectionMapWinners: ElectionMapWinners = [
   { id: 4862, winner: { name: "UDMR", partyColor: "green", votes: 550 }, validVotes: 1000 },
 ];
 
+export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
+  {
+    id: 1,
+    validVotes: 148783,
+    winner: {
+      name: "DUMITREL ION",
+      partyColor: "#F8DD1B",
+      votes: 82945,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 10886,
+    validVotes: 108611,
+    winner: {
+      name: "PAVEL MARIAN",
+      partyColor: "#FF0000",
+      votes: 37068,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 11169,
+    validVotes: 275640,
+    winner: {
+      name: "ALEXE COSTEL",
+      partyColor: "#F8DD1B",
+      votes: 104656,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 11830,
+    validVotes: 185177,
+    winner: {
+      name: "THUMA HUBERT PETRU ŞTEFAN",
+      partyColor: "#F8DD1B",
+      votes: 89860,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 12053,
+    validVotes: 184729,
+    winner: {
+      name: "BOGDAN IONEL-OVIDIU",
+      partyColor: "#F8DD1B",
+      votes: 64264,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 12539,
+    validVotes: 120967,
+    winner: {
+      name: "GEORGESCU ALADIN-GIGI",
+      partyColor: "#FF0000",
+      votes: 54313,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 13227,
+    validVotes: 221428,
+    winner: {
+      name: "PÉTER FERENC",
+      partyColor: "#007300",
+      votes: 85673,
+      party: {
+        id: 21,
+        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+        shortName: "UDMR",
+        logoUrl:
+          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+        color: "#007300",
+      },
+    },
+  },
+  {
+    id: 13933,
+    validVotes: 186431,
+    winner: {
+      name: "ARSENE IONEL",
+      shortName: "ALIANȚA ELECTORALĂ \"ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020\"",
+      partyColor: "#808080",
+      votes: 77208,
+      party: { id: 0, name: "ALIANȚA ELECTORALĂ \"ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020\"" },
+    },
+  },
+  {
+    id: 14365,
+    validVotes: 202234,
+    winner: {
+      name: "OPRESCU MARIUS",
+      partyColor: "#FF0000",
+      votes: 109957,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 14895,
+    validVotes: 292875,
+    winner: {
+      name: "DUMITRESCU IULIAN",
+      shortName: "ALIANȚA PNL USR PLUS",
+      partyColor: "#808080",
+      votes: 137286,
+      party: { id: 0, name: "ALIANȚA PNL USR PLUS" },
+    },
+  },
+  {
+    id: 15592,
+    validVotes: 98590,
+    winner: {
+      name: "IANCU-SĂLĂJANU DINU",
+      partyColor: "#F8DD1B",
+      votes: 38464,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 16002,
+    validVotes: 133862,
+    winner: {
+      name: "PATAKI CSABA",
+      partyColor: "#007300",
+      votes: 52371,
+      party: {
+        id: 21,
+        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+        shortName: "UDMR",
+        logoUrl:
+          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+        color: "#007300",
+      },
+    },
+  },
+  {
+    id: 16392,
+    validVotes: 155172,
+    winner: {
+      name: "CÎMPEAN DANIELA",
+      partyColor: "#F8DD1B",
+      votes: 72757,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 17391,
+    validVotes: 257169,
+    winner: {
+      name: "FLUTUR GHEORGHE",
+      partyColor: "#F8DD1B",
+      votes: 106960,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 18142,
+    validVotes: 166754,
+    winner: {
+      name: "GÂDEA ADRIAN-IONUŢ",
+      partyColor: "#FF0000",
+      votes: 71584,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 18648,
+    validVotes: 259660,
+    winner: {
+      name: "NICA ALIN-ADRIAN",
+      partyColor: "#F8DD1B",
+      votes: 104508,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 19284,
+    validVotes: 86807,
+    winner: {
+      name: "TEODORESCU HORIA",
+      partyColor: "#FF0000",
+      votes: 33294,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 19520,
+    validVotes: 158865,
+    winner: {
+      name: "RĂDULESCU CONSTANTIN",
+      partyColor: "#FF0000",
+      votes: 74129,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 10251,
+    validVotes: 164488,
+    winner: {
+      name: "NISTOR LAURENŢIU",
+      partyColor: "#FF0000",
+      votes: 71052,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 9866,
+    validVotes: 108176,
+    winner: {
+      name: "BORBOLY CSABA",
+      partyColor: "#007300",
+      votes: 69822,
+      party: {
+        id: 21,
+        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+        shortName: "UDMR",
+        logoUrl:
+          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+        color: "#007300",
+      },
+    },
+  },
+  {
+    id: 9449,
+    validVotes: 151090,
+    winner: {
+      name: "POPESCU COSMIN-MIHAI",
+      partyColor: "#FF0000",
+      votes: 66109,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 9134,
+    validVotes: 123521,
+    winner: {
+      name: "BEIANU DUMITRU",
+      partyColor: "#F8DD1B",
+      votes: 60255,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 589,
+    validVotes: 163446,
+    winner: {
+      name: "CIONCA-ARGHIR IUSTIN-MARINEL",
+      partyColor: "#F8DD1B",
+      votes: 77318,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 1122,
+    validVotes: 246587,
+    winner: {
+      name: "MÎNZÎNĂ ION",
+      partyColor: "#FF0000",
+      votes: 104269,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 1814,
+    validVotes: 230731,
+    winner: {
+      name: "IVANCEA VALENTIN",
+      partyColor: "#FF0000",
+      votes: 94669,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 2513,
+    validVotes: 254022,
+    winner: {
+      name: "BOLOJAN ILIE-GAVRIL",
+      partyColor: "#F8DD1B",
+      votes: 156241,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 3325,
+    validVotes: 127608,
+    winner: {
+      name: "MOLDOVAN EMIL RADU",
+      shortName: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD",
+      partyColor: "#808080",
+      votes: 66039,
+      party: { id: 0, name: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD" },
+    },
+  },
+  {
+    id: 3747,
+    validVotes: 153169,
+    winner: {
+      name: "FEDEROVICI DOINA-ELENA",
+      partyColor: "#FF0000",
+      votes: 65688,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 4231,
+    validVotes: 109582,
+    winner: {
+      name: "CHIRIAC FRANCISK-IULIAN",
+      partyColor: "#FF0000",
+      votes: 55547,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 4481,
+    validVotes: 206315,
+    winner: {
+      name: "VEŞTEA ADRIAN-IOAN",
+      partyColor: "#F8DD1B",
+      votes: 95615,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 20009,
+    validVotes: 147886,
+    winner: {
+      name: "BUZATU DUMITRU",
+      partyColor: "#FF0000",
+      votes: 57283,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 12913,
+    validVotes: 660118,
+    winner: { name: "DAN NICUŞOR DANIEL", partyColor: "#808080", votes: 282631 },
+  },
+  {
+    id: 5400,
+    validVotes: 128072,
+    winner: {
+      name: "ILIUŢĂ VASILE",
+      partyColor: "#FF0000",
+      votes: 57100,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 5676,
+    validVotes: 120336,
+    winner: {
+      name: "DUNCA ROMEO-DAN",
+      partyColor: "#F8DD1B",
+      votes: 51488,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 6150,
+    validVotes: 252208,
+    winner: {
+      name: "TIŞE ALIN-PĂUNEL",
+      partyColor: "#F8DD1B",
+      votes: 127251,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 6793,
+    validVotes: 272317,
+    winner: {
+      name: "LUPU MIHAI",
+      partyColor: "#F8DD1B",
+      votes: 101893,
+      party: {
+        id: 3,
+        name: "Partidul Național Liberal",
+        shortName: "PNL",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+        color: "#F8DD1B",
+        alias: "PARTIDUL NAȚIONAL LIBERAL",
+      },
+    },
+  },
+  {
+    id: 7308,
+    validVotes: 68977,
+    winner: {
+      name: "TAMÁS SÁNDOR",
+      partyColor: "#007300",
+      votes: 43391,
+      party: {
+        id: 21,
+        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+        shortName: "UDMR",
+        logoUrl:
+          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+        color: "#007300",
+      },
+    },
+  },
+  {
+    id: 7588,
+    validVotes: 216741,
+    winner: {
+      name: "ŞTEFAN CORNELIU",
+      partyColor: "#FF0000",
+      votes: 100064,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 8114,
+    validVotes: 263874,
+    winner: {
+      name: "VASILE DORIN-COSMIN",
+      shortName: "AEPD",
+      partyColor: "#808080",
+      votes: 111317,
+      party: { id: 0, name: "ALIANTA ELECTORALA PSD+ALDE DOLJ" },
+    },
+  },
+  {
+    id: 8747,
+    validVotes: 198893,
+    winner: {
+      name: "FOTEA COSTEL",
+      partyColor: "#FF0000",
+      votes: 97109,
+      party: {
+        id: 13,
+        name: "Partidul Social Democrat",
+        shortName: "PSD",
+        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+        color: "#FF0000",
+        alias: "PARTIDUL SOCIAL DEMOCRAT",
+      },
+    },
+  },
+  {
+    id: 4862,
+    validVotes: 180641,
+    winner: {
+      name: "NEAGU PETRE-EMANOIL",
+      shortName: "ALIANȚA PSD-PRO BUZĂU",
+      partyColor: "#808080",
+      votes: 100312,
+      party: { id: 0, name: "ALIANȚA PSD-PRO BUZĂU" },
+    },
+  },
+  {
+    id: 20574,
+    validVotes: 144962,
+    winner: {
+      name: "TOMA CĂTĂLIN DUMITRU",
+      shortName:
+        "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
+      partyColor: "#808080",
+      votes: 65637,
+      party: {
+        id: 0,
+        name:
+          "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
+      },
+    },
+  },
+];
+
 // To fake loading times
 const delay = (timeout: number) => new Promise((resolve) => setTimeout(resolve, timeout));
 
@@ -1007,7 +1681,11 @@ export const mockElectionAPI = makeElectionApi({
       }) as APIMockHandler<{ id: number; name: string }[]>,
     ],
 
-    ["GET", "/winners/counties", (async () => mockElectionMapWinners) as APIMockHandler<ElectionMapWinners>],
+    [
+      "GET",
+      "/winners/counties",
+      (async () => mockElectionCountyCouncilMapWinners) as APIMockHandler<ElectionMapWinners>,
+    ],
     ["GET", "/winners/countries", (async () => mockElectionMapWinners) as APIMockHandler<ElectionMapWinners>],
     ["GET", "/winners/localities", (async () => mockElectionMapWinners) as APIMockHandler<ElectionMapWinners>],
   ]),

--- a/src/util/mocks.ts
+++ b/src/util/mocks.ts
@@ -190,6 +190,57 @@ export const mockResults: ElectionResults = {
   ],
 };
 
+export const mockMayorResults = {
+  eligibleVoters: 393847,
+  totalVotes: 175789,
+  validVotes: 170594,
+  nullVotes: 5195,
+  totalSeats: 0,
+  candidates: [
+    {
+      name: "Partidul Național Liberal",
+      partyColor: "#F8DD1B",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
+      votes: 49,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "Partidul Social Democrat",
+      partyColor: "#FF0000",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
+      votes: 15,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "INDEPENDENT",
+      shortName: "INDEPENDENT",
+      partyColor: "#808080",
+      votes: 8,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
+      partyColor: "#007300",
+      partyLogo:
+        "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
+      votes: 5,
+      seats: 0,
+      totalSeats: 0,
+    },
+    {
+      name: "PARTIDUL PRO ROMÂNIA",
+      partyColor: "#FF4C4C",
+      partyLogo: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Pro+Romania.jpg",
+      votes: 1,
+      seats: 0,
+      totalSeats: 0,
+    },
+  ],
+};
+
 export const mockCountyCouncilResults = {
   eligibleVoters: 18466219,
   totalVotes: 8419716,
@@ -1311,6 +1362,687 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
   },
 ];
 
+export const mockMayorElectionWinners = [
+  {
+    id: 2,
+    validVotes: 1013,
+    winner: {
+      name: "TODEA PETRU-TIBERIU",
+      partyColor: "#F8DD1B",
+      votes: 796,
+    },
+  },
+  {
+    id: 451,
+    validVotes: 672,
+    winner: {
+      name: "BULGĂR IONEL",
+      partyColor: "#F8DD1B",
+      votes: 417,
+    },
+  },
+  {
+    id: 447,
+    validVotes: 504,
+    winner: {
+      name: "PETRUŢ BUJOR",
+      partyColor: "#F8DD1B",
+      votes: 366,
+    },
+  },
+  {
+    id: 445,
+    validVotes: 642,
+    winner: {
+      name: "TOADER BENIAMIN",
+      partyColor: "#F8DD1B",
+      votes: 366,
+    },
+  },
+  {
+    id: 438,
+    validVotes: 1687,
+    winner: {
+      name: "PETRUSE MARIN-IOAN",
+      partyColor: "#F8DD1B",
+      votes: 1006,
+    },
+  },
+  {
+    id: 425,
+    validVotes: 3557,
+    winner: {
+      name: "PONORAN SILVIU",
+      partyColor: "#F8DD1B",
+      votes: 2054,
+    },
+  },
+  {
+    id: 416,
+    validVotes: 2921,
+    winner: {
+      name: "HĂLĂLAI MIREL-VASILE",
+      partyColor: "#FF0000",
+      votes: 1654,
+    },
+  },
+  {
+    id: 403,
+    validVotes: 4210,
+    winner: {
+      name: "VINŢELER SILVIU",
+      partyColor: "#F8DD1B",
+      votes: 3305,
+    },
+  },
+  {
+    id: 379,
+    validVotes: 8207,
+    winner: {
+      name: "TEBAN ADRIAN OVIDIU",
+      partyColor: "#F8DD1B",
+      votes: 4128,
+    },
+  },
+  {
+    id: 368,
+    validVotes: 4171,
+    winner: {
+      name: "PAŞCA CRISTIAN-DAN",
+      partyColor: "#F8DD1B",
+      votes: 2103,
+    },
+  },
+  {
+    id: 359,
+    validVotes: 1814,
+    winner: {
+      name: "PANDOR TRAIAN",
+      partyColor: "#F8DD1B",
+      votes: 676,
+    },
+  },
+  {
+    id: 353,
+    validVotes: 2283,
+    winner: {
+      name: "ALBU CRISTIAN ALEXANDRU",
+      partyColor: "#F8DD1B",
+      votes: 952,
+    },
+  },
+  {
+    id: 348,
+    validVotes: 454,
+    winner: {
+      name: "MIHĂLŢAN ADRIAN-NICOLAE",
+      partyColor: "#F8DD1B",
+      votes: 231,
+    },
+  },
+  {
+    id: 342,
+    validVotes: 406,
+    winner: {
+      name: "JUCAN ALIN-ALEXANDRU",
+      partyColor: "#F8DD1B",
+      votes: 348,
+    },
+  },
+  {
+    id: 337,
+    validVotes: 749,
+    winner: {
+      name: "ZILAHI FLORIN-CLAUDIU",
+      partyColor: "#F8DD1B",
+      votes: 499,
+    },
+  },
+  {
+    id: 315,
+    validVotes: 10476,
+    winner: {
+      name: "NISTOR DORIN GHEORGHE",
+      partyColor: "#F8DD1B",
+      votes: 6476,
+    },
+  },
+  {
+    id: 458,
+    validVotes: 742,
+    winner: {
+      name: "NICULA ALIN-TEODOR",
+      partyColor: "#F8DD1B",
+      votes: 670,
+    },
+  },
+  {
+    id: 463,
+    validVotes: 345,
+    winner: {
+      name: "RAICA VASILE",
+      partyColor: "#FF0000",
+      votes: 285,
+    },
+  },
+  {
+    id: 472,
+    validVotes: 772,
+    winner: {
+      name: "CRISTEA IOAN",
+      partyColor: "#FF0000",
+      votes: 395,
+    },
+  },
+  {
+    id: 477,
+    validVotes: 1585,
+    winner: {
+      name: "FURDUI EUGEN",
+      partyColor: "#F8DD1B",
+      votes: 563,
+    },
+  },
+  {
+    id: 575,
+    validVotes: 977,
+    winner: {
+      name: "PETRICELE DORU",
+      partyColor: "#FF0000",
+      votes: 529,
+    },
+  },
+  {
+    id: 567,
+    validVotes: 1685,
+    winner: {
+      name: "ALDEA DAN-FLORIN",
+      partyColor: "#660066",
+      votes: 970,
+    },
+  },
+  {
+    id: 564,
+    validVotes: 948,
+    winner: {
+      name: "LAZEA NICOLAE",
+      partyColor: "#F8DD1B",
+      votes: 499,
+    },
+  },
+  {
+    id: 554,
+    validVotes: 1955,
+    winner: {
+      name: "ALBA GHEORGHE",
+      partyColor: "#F8DD1B",
+      votes: 1102,
+    },
+  },
+  {
+    id: 549,
+    validVotes: 1340,
+    winner: {
+      name: "JINAR CONSTANTIN",
+      partyColor: "#F8DD1B",
+      votes: 1111,
+    },
+  },
+  {
+    id: 544,
+    validVotes: 1350,
+    winner: {
+      name: "POPA TRAIAN ŞTEFAN",
+      partyColor: "#FF0000",
+      votes: 754,
+    },
+  },
+  {
+    id: 538,
+    validVotes: 1482,
+    winner: {
+      name: "STĂNILĂ IULIA",
+      partyColor: "#F8DD1B",
+      votes: 752,
+    },
+  },
+  {
+    id: 296,
+    validVotes: 6991,
+    winner: {
+      name: "ROTAR GHEORGHE-VALENTIN",
+      partyColor: "#F8DD1B",
+      votes: 5516,
+    },
+  },
+  {
+    id: 531,
+    validVotes: 1816,
+    winner: {
+      name: "MĂRGINEAN TEODOR-FLORIN",
+      partyColor: "#F8DD1B",
+      votes: 1232,
+    },
+  },
+  {
+    id: 520,
+    validVotes: 1273,
+    winner: {
+      name: "OANĂ MARINELA",
+      partyColor: "#F8DD1B",
+      votes: 429,
+    },
+  },
+  {
+    id: 511,
+    validVotes: 953,
+    winner: {
+      name: "COSTEA CRISTIAN-VASILE",
+      partyColor: "#F8DD1B",
+      votes: 493,
+    },
+  },
+  {
+    id: 503,
+    validVotes: 2702,
+    winner: {
+      name: "MORAR NICOLAE-FLORIN",
+      partyColor: "#F8DD1B",
+      votes: 1033,
+    },
+  },
+  {
+    id: 498,
+    validVotes: 1427,
+    winner: {
+      name: "POPA IOAN-IANCU",
+      partyColor: "#F8DD1B",
+      votes: 833,
+    },
+  },
+  {
+    id: 493,
+    validVotes: 1201,
+    winner: {
+      name: "FRĂŢILĂ ILIE",
+      partyColor: "#F8DD1B",
+      votes: 675,
+    },
+  },
+  {
+    id: 487,
+    validVotes: 1410,
+    winner: {
+      name: "STĂNILĂ AUREL-EMIL",
+      partyColor: "#F8DD1B",
+      votes: 604,
+    },
+  },
+  {
+    id: 483,
+    validVotes: 790,
+    winner: {
+      name: "LOMBREA VASILE",
+      partyColor: "#F8DD1B",
+      votes: 403,
+    },
+  },
+  {
+    id: 526,
+    validVotes: 849,
+    winner: {
+      name: "CORCHEŞ SORIN-CONSTANTIN",
+      partyColor: "#F8DD1B",
+      votes: 569,
+    },
+  },
+  {
+    id: 246,
+    validVotes: 22024,
+    winner: {
+      name: "PLEŞA GABRIEL-CODRU",
+      partyColor: "#01A0E4",
+      votes: 8107,
+    },
+  },
+  {
+    id: 220,
+    validVotes: 8123,
+    winner: {
+      name: "BADEA IULIA-ADRIANA-OANA",
+      partyColor: "#F8DD1B",
+      votes: 3729,
+    },
+  },
+  {
+    id: 215,
+    validVotes: 467,
+    winner: {
+      name: "MACAVEI MIRCEA-LIVIU",
+      partyColor: "#F8DD1B",
+      votes: 209,
+    },
+  },
+  {
+    id: 87,
+    validVotes: 1057,
+    winner: {
+      name: "BUBUR LENUŢA",
+      partyColor: "#F8DD1B",
+      votes: 608,
+    },
+  },
+  {
+    id: 83,
+    validVotes: 704,
+    winner: {
+      name: "TUHUŢ RADU-MARCEL",
+      partyColor: "#FF0000",
+      votes: 619,
+    },
+  },
+  { id: 75, validVotes: 1733, winner: { name: "DĂMIAN GHEORGHE", partyColor: "#808080", votes: 1527 } },
+  {
+    id: 68,
+    validVotes: 1156,
+    winner: {
+      name: "COMANDARU CONSTANTIN",
+      partyColor: "#F8DD1B",
+      votes: 844,
+    },
+  },
+  {
+    id: 65,
+    validVotes: 240,
+    winner: {
+      name: "TRIF IOAN",
+      partyColor: "#000099",
+      votes: 163,
+    },
+  },
+  {
+    id: 60,
+    validVotes: 910,
+    winner: {
+      name: "ALDEA LENUŢA",
+      partyColor: "#F8DD1B",
+      votes: 596,
+    },
+  },
+  {
+    id: 57,
+    validVotes: 438,
+    winner: {
+      name: "NEAMŢU ILIE",
+      partyColor: "#F8DD1B",
+      votes: 413,
+    },
+  },
+  {
+    id: 91,
+    validVotes: 1211,
+    winner: {
+      name: "TODERICIU AUREL-FLORIN",
+      partyColor: "#B2B200",
+      votes: 650,
+    },
+  },
+  { id: 53, validVotes: 1048, winner: { name: "BODEA LUCIAN-TIBERIU", partyColor: "#808080", votes: 499 } },
+  {
+    id: 43,
+    validVotes: 1117,
+    winner: {
+      name: "ALDEA IOAN",
+      partyColor: "#F8DD1B",
+      votes: 619,
+    },
+  },
+  {
+    id: 38,
+    validVotes: 642,
+    winner: {
+      name: "GHERMAN NICOLAE",
+      partyColor: "#F8DD1B",
+      votes: 412,
+    },
+  },
+  {
+    id: 31,
+    validVotes: 2040,
+    winner: {
+      name: "GLIGOR TRAIAN",
+      partyColor: "#F8DD1B",
+      votes: 1609,
+    },
+  },
+  {
+    id: 25,
+    validVotes: 679,
+    winner: {
+      name: "BICA VASILE",
+      partyColor: "#F8DD1B",
+      votes: 523,
+    },
+  },
+  {
+    id: 21,
+    validVotes: 857,
+    winner: {
+      name: "HELER SANDU",
+      partyColor: "#F8DD1B",
+      votes: 675,
+    },
+  },
+  {
+    id: 16,
+    validVotes: 1253,
+    winner: {
+      name: "PANTEA GHEORGHE",
+      partyColor: "#F8DD1B",
+      votes: 657,
+    },
+  },
+  {
+    id: 9,
+    validVotes: 820,
+    winner: {
+      name: "ZAHARIE ARON",
+      partyColor: "#F8DD1B",
+      votes: 325,
+    },
+  },
+  {
+    id: 47,
+    validVotes: 763,
+    winner: {
+      name: "NAPĂU CORNEL",
+      partyColor: "#FF0000",
+      votes: 560,
+    },
+  },
+  {
+    id: 580,
+    validVotes: 2550,
+    winner: {
+      name: "BARBU PETRU-IOAN",
+      partyColor: "#F8DD1B",
+      votes: 960,
+    },
+  },
+  {
+    id: 96,
+    validVotes: 724,
+    winner: {
+      name: "BÂSCĂ SORIN-GHEORGHE",
+      partyColor: "#F8DD1B",
+      votes: 422,
+    },
+  },
+  {
+    id: 103,
+    validVotes: 541,
+    winner: {
+      name: "CÎNDEA EMILIA-LIVIA",
+      partyColor: "#F8DD1B",
+      votes: 430,
+    },
+  },
+  {
+    id: 208,
+    validVotes: 911,
+    winner: {
+      name: "ALEXANDRU LIVIU-GIGEL",
+      partyColor: "#F8DD1B",
+      votes: 457,
+    },
+  },
+  {
+    id: 202,
+    validVotes: 1909,
+    winner: {
+      name: "BREAZ FLAVIUS",
+      partyColor: "#F8DD1B",
+      votes: 1188,
+    },
+  },
+  {
+    id: 194,
+    validVotes: 1560,
+    winner: {
+      name: "OPRUŢA DAN-COSMIN",
+      partyColor: "#F8DD1B",
+      votes: 776,
+    },
+  },
+  {
+    id: 188,
+    validVotes: 1725,
+    winner: {
+      name: "PENCIU IOAN-RADU",
+      partyColor: "#01A0E4",
+      votes: 825,
+    },
+  },
+  {
+    id: 183,
+    validVotes: 1308,
+    winner: {
+      name: "CSEGEZI EDIT-SUSANA",
+      partyColor: "#007300",
+      votes: 569,
+    },
+  },
+  {
+    id: 175,
+    validVotes: 1714,
+    winner: {
+      name: "INDREIU MARIAN-CĂTĂLIN",
+      partyColor: "#F8DD1B",
+      votes: 1013,
+    },
+  },
+  {
+    id: 169,
+    validVotes: 813,
+    winner: {
+      name: "HAN HORAŢIU-NICOLAE",
+      partyColor: "#F8DD1B",
+      votes: 599,
+    },
+  },
+  {
+    id: 99,
+    validVotes: 1461,
+    winner: {
+      name: "HĂPRIAN VISARION",
+      partyColor: "#F8DD1B",
+      votes: 1244,
+    },
+  },
+  {
+    id: 162,
+    validVotes: 2357,
+    winner: {
+      name: "TRIF ALIN",
+      partyColor: "#F8DD1B",
+      votes: 2123,
+    },
+  },
+  {
+    id: 148,
+    validVotes: 3050,
+    winner: {
+      name: "RUSU TRAIAN",
+      partyColor: "#F8DD1B",
+      votes: 1581,
+    },
+  },
+  {
+    id: 140,
+    validVotes: 1174,
+    winner: {
+      name: "NICOLA MARIN",
+      partyColor: "#F8DD1B",
+      votes: 824,
+    },
+  },
+  {
+    id: 133,
+    validVotes: 527,
+    winner: {
+      name: "POPA AUGUSTIN",
+      partyColor: "#F8DD1B",
+      votes: 455,
+    },
+  },
+  {
+    id: 128,
+    validVotes: 884,
+    winner: {
+      name: "VÎRCIU MARIN",
+      partyColor: "#F8DD1B",
+      votes: 427,
+    },
+  },
+  {
+    id: 123,
+    validVotes: 1041,
+    winner: {
+      name: "MUNTEAN IOAN",
+      partyColor: "#FF0000",
+      votes: 526,
+    },
+  },
+  {
+    id: 114,
+    validVotes: 2048,
+    winner: {
+      name: "RAICA ROMULUS",
+      partyColor: "#F8DD1B",
+      votes: 765,
+    },
+  },
+  {
+    id: 107,
+    validVotes: 872,
+    winner: {
+      name: "STOIA IOAN",
+      partyColor: "#F8DD1B",
+      votes: 720,
+    },
+  },
+  { id: 156, validVotes: 391, winner: { name: "MOGA VICTORIA", partyColor: "#808080", votes: 219 } },
+  {
+    id: 108885,
+    validVotes: 544,
+    winner: {
+      name: "DEÁK-SZÉKELY SZILÁRD-LEVENTE",
+      partyColor: "#007300",
+      votes: 326,
+    },
+  },
+];
+
 // To fake loading times
 const delay = (timeout: number) => new Promise((resolve) => setTimeout(resolve, timeout));
 
@@ -1397,6 +2129,6 @@ export const mockElectionAPI = makeElectionApi({
       (async () => mockElectionCountyCouncilMapWinners) as APIMockHandler<ElectionMapWinners>,
     ],
     ["GET", "/winners/countries", (async () => mockElectionMapWinners) as APIMockHandler<ElectionMapWinners>],
-    ["GET", "/winners/localities", (async () => mockElectionMapWinners) as APIMockHandler<ElectionMapWinners>],
+    ["GET", "/winners/localities", (async () => mockMayorElectionWinners) as APIMockHandler<ElectionMapWinners>],
   ]),
 });

--- a/src/util/mocks.ts
+++ b/src/util/mocks.ts
@@ -935,14 +935,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "DUMITREL ION",
       partyColor: "#F8DD1B",
       votes: 82945,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -952,14 +944,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "PAVEL MARIAN",
       partyColor: "#FF0000",
       votes: 37068,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -969,14 +953,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "ALEXE COSTEL",
       partyColor: "#F8DD1B",
       votes: 104656,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -986,14 +962,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "THUMA HUBERT PETRU ŞTEFAN",
       partyColor: "#F8DD1B",
       votes: 89860,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1003,14 +971,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "BOGDAN IONEL-OVIDIU",
       partyColor: "#F8DD1B",
       votes: 64264,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1020,14 +980,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "GEORGESCU ALADIN-GIGI",
       partyColor: "#FF0000",
       votes: 54313,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1037,14 +989,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "PÉTER FERENC",
       partyColor: "#007300",
       votes: 85673,
-      party: {
-        id: 21,
-        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
-        shortName: "UDMR",
-        logoUrl:
-          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
-        color: "#007300",
-      },
     },
   },
   {
@@ -1052,10 +996,9 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
     validVotes: 186431,
     winner: {
       name: "ARSENE IONEL",
-      shortName: "ALIANȚA ELECTORALĂ \"ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020\"",
+      shortName: "ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020",
       partyColor: "#808080",
       votes: 77208,
-      party: { id: 0, name: "ALIANȚA ELECTORALĂ \"ALIANȚA PENTRU MODERNIZAREA NEAMȚULUI 2020\"" },
     },
   },
   {
@@ -1065,14 +1008,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "OPRESCU MARIUS",
       partyColor: "#FF0000",
       votes: 109957,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1083,7 +1018,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       shortName: "ALIANȚA PNL USR PLUS",
       partyColor: "#808080",
       votes: 137286,
-      party: { id: 0, name: "ALIANȚA PNL USR PLUS" },
     },
   },
   {
@@ -1093,14 +1027,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "IANCU-SĂLĂJANU DINU",
       partyColor: "#F8DD1B",
       votes: 38464,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1110,14 +1036,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "PATAKI CSABA",
       partyColor: "#007300",
       votes: 52371,
-      party: {
-        id: 21,
-        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
-        shortName: "UDMR",
-        logoUrl:
-          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
-        color: "#007300",
-      },
     },
   },
   {
@@ -1127,14 +1045,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "CÎMPEAN DANIELA",
       partyColor: "#F8DD1B",
       votes: 72757,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1144,14 +1054,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "FLUTUR GHEORGHE",
       partyColor: "#F8DD1B",
       votes: 106960,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1161,14 +1063,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "GÂDEA ADRIAN-IONUŢ",
       partyColor: "#FF0000",
       votes: 71584,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1178,14 +1072,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "NICA ALIN-ADRIAN",
       partyColor: "#F8DD1B",
       votes: 104508,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1195,14 +1081,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "TEODORESCU HORIA",
       partyColor: "#FF0000",
       votes: 33294,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1212,14 +1090,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "RĂDULESCU CONSTANTIN",
       partyColor: "#FF0000",
       votes: 74129,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1229,14 +1099,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "NISTOR LAURENŢIU",
       partyColor: "#FF0000",
       votes: 71052,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1246,14 +1108,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "BORBOLY CSABA",
       partyColor: "#007300",
       votes: 69822,
-      party: {
-        id: 21,
-        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
-        shortName: "UDMR",
-        logoUrl:
-          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
-        color: "#007300",
-      },
     },
   },
   {
@@ -1263,14 +1117,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "POPESCU COSMIN-MIHAI",
       partyColor: "#FF0000",
       votes: 66109,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1280,14 +1126,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "BEIANU DUMITRU",
       partyColor: "#F8DD1B",
       votes: 60255,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1297,14 +1135,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "CIONCA-ARGHIR IUSTIN-MARINEL",
       partyColor: "#F8DD1B",
       votes: 77318,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1314,14 +1144,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "MÎNZÎNĂ ION",
       partyColor: "#FF0000",
       votes: 104269,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1331,14 +1153,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "IVANCEA VALENTIN",
       partyColor: "#FF0000",
       votes: 94669,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1348,14 +1162,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "BOLOJAN ILIE-GAVRIL",
       partyColor: "#F8DD1B",
       votes: 156241,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1366,7 +1172,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       shortName: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD",
       partyColor: "#808080",
       votes: 66039,
-      party: { id: 0, name: "ALIANȚA PENTRU BISTRIȚA-NĂSĂUD" },
     },
   },
   {
@@ -1376,14 +1181,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "FEDEROVICI DOINA-ELENA",
       partyColor: "#FF0000",
       votes: 65688,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1393,14 +1190,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "CHIRIAC FRANCISK-IULIAN",
       partyColor: "#FF0000",
       votes: 55547,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1410,14 +1199,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "VEŞTEA ADRIAN-IOAN",
       partyColor: "#F8DD1B",
       votes: 95615,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1427,14 +1208,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "BUZATU DUMITRU",
       partyColor: "#FF0000",
       votes: 57283,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1449,14 +1222,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "ILIUŢĂ VASILE",
       partyColor: "#FF0000",
       votes: 57100,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1466,14 +1231,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "DUNCA ROMEO-DAN",
       partyColor: "#F8DD1B",
       votes: 51488,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1483,14 +1240,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "TIŞE ALIN-PĂUNEL",
       partyColor: "#F8DD1B",
       votes: 127251,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1500,14 +1249,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "LUPU MIHAI",
       partyColor: "#F8DD1B",
       votes: 101893,
-      party: {
-        id: 3,
-        name: "Partidul Național Liberal",
-        shortName: "PNL",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Na%C8%9Bional+Liberal.jpg",
-        color: "#F8DD1B",
-        alias: "PARTIDUL NAȚIONAL LIBERAL",
-      },
     },
   },
   {
@@ -1517,14 +1258,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "TAMÁS SÁNDOR",
       partyColor: "#007300",
       votes: 43391,
-      party: {
-        id: 21,
-        name: "UNIUNEA DEMOCRATA MAGHIARA DIN ROMANIA",
-        shortName: "UDMR",
-        logoUrl:
-          "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Uniunea+Democrat%C4%83+a+Maghiarilor+din+Rom%C3%A2nia.jpg",
-        color: "#007300",
-      },
     },
   },
   {
@@ -1534,14 +1267,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "ŞTEFAN CORNELIU",
       partyColor: "#FF0000",
       votes: 100064,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1552,7 +1277,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       shortName: "AEPD",
       partyColor: "#808080",
       votes: 111317,
-      party: { id: 0, name: "ALIANTA ELECTORALA PSD+ALDE DOLJ" },
     },
   },
   {
@@ -1562,14 +1286,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       name: "FOTEA COSTEL",
       partyColor: "#FF0000",
       votes: 97109,
-      party: {
-        id: 13,
-        name: "Partidul Social Democrat",
-        shortName: "PSD",
-        logoUrl: "https://rezultatevot-media.s3.eu-central-1.amazonaws.com/v2/Logo__Partidul+Social+Democrat.jpg",
-        color: "#FF0000",
-        alias: "PARTIDUL SOCIAL DEMOCRAT",
-      },
     },
   },
   {
@@ -1580,7 +1296,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
       shortName: "ALIANȚA PSD-PRO BUZĂU",
       partyColor: "#808080",
       votes: 100312,
-      party: { id: 0, name: "ALIANȚA PSD-PRO BUZĂU" },
     },
   },
   {
@@ -1592,11 +1307,6 @@ export const mockElectionCountyCouncilMapWinners: ElectionMapWinners = [
         "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
       partyColor: "#808080",
       votes: 65637,
-      party: {
-        id: 0,
-        name:
-          "ALIANȚA PARTIDUL NAȚIONAL LIBERAL - UNIUNEA SALVAȚI ROMÂNIA - PARTIDUL LIBERTATE, UNITATE ȘI SOLIDARITATE (PNL-USR-PLUS)",
-      },
     },
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "include": [ "src/**/*" ],
+    "lib": ["es2016"],
     "compilerOptions": {
         "target": "es6",
         "jsx": "react",


### PR DESCRIPTION
Aiming at helping with this: https://github.com/code4romania/rezultate-vot-client/issues/86

The change shows the actual number of votes instead of percentages for the kind of elections that don't have the results expressed in number of votes (eg. showing at a national level the number of mayors each party has). The underlying assumption is that the API is returning those values inside the votes field