### PR TITLE
Group Stroybook stories by 'Election' / 'Election results'

### DIFF
--- a/src/components/ElectionMap/ElectionMap.stories.tsx
+++ b/src/components/ElectionMap/ElectionMap.stories.tsx
@@ -9,7 +9,7 @@ import { mockElectionAPI } from "../../util/mocks";
 import { ElectionMap } from "./ElectionMap";
 
 export default {
-  title: "Election map",
+  title: "Election / Map",
   component: ElectionMap,
   argTypes: {
     ...scopeArgTypes,

--- a/src/components/ElectionNewsCard/ElectionNewsCard.stories.js
+++ b/src/components/ElectionNewsCard/ElectionNewsCard.stories.js
@@ -3,7 +3,7 @@ import { ElectionNewsCard } from "./ElectionNewsCard.tsx";
 import { mockElectionNews } from "../../util/mocks";
 
 export default {
-  title: "Election news card",
+  title: "Election / News card",
   component: ElectionNewsCard,
 };
 

--- a/src/components/ElectionNewsSection/ElectionNewsSection.stories.js
+++ b/src/components/ElectionNewsSection/ElectionNewsSection.stories.js
@@ -3,7 +3,7 @@ import { ElectionNewsSection } from "./ElectionNewsSection.tsx";
 import { mockElectionNews } from "../../util/mocks";
 
 export default {
-  title: "Election news section",
+  title: "Election / News section",
   component: ElectionNewsSection,
 };
 

--- a/src/components/ElectionObservationSection/ElectionObservationSection.stories.tsx
+++ b/src/components/ElectionObservationSection/ElectionObservationSection.stories.tsx
@@ -5,7 +5,7 @@ import { mockObservation } from "../../util/mocks";
 import { ElectionObservationSection } from "./ElectionObservationSection";
 
 export default {
-  title: "Election observation section",
+  title: "Election / Observation section",
   component: ElectionObservationSection,
 };
 

--- a/src/components/ElectionResultsDiscreteTableSection/ElectionResultsDiscreteTableSection.stories.tsx
+++ b/src/components/ElectionResultsDiscreteTableSection/ElectionResultsDiscreteTableSection.stories.tsx
@@ -6,7 +6,7 @@ import { ElectionResultsDiscreteTableSection } from "./ElectionResultsDiscreteTa
 import cssClasses from "./ElectionResultsDiscreteTableSection.module.scss";
 
 export default {
-  title: "Election results discrete tables section",
+  title: "Election results / Discrete tables section",
   component: ElectionResultsDiscreteTableSection,
 };
 

--- a/src/components/ElectionResultsProcess/ElectionResultsProcess.stories.tsx
+++ b/src/components/ElectionResultsProcess/ElectionResultsProcess.stories.tsx
@@ -5,7 +5,7 @@ import { mockResults } from "../../util/mocks";
 import { ElectionResultsProcess } from "./ElectionResultsProcess";
 
 export default {
-  title: "Election results electoral process",
+  title: "Election results / Electoral process",
   component: ElectionResultsProcess,
 };
 

--- a/src/components/ElectionResultsSeats/ElectionResultsSeats.stories.tsx
+++ b/src/components/ElectionResultsSeats/ElectionResultsSeats.stories.tsx
@@ -5,7 +5,7 @@ import { mockResults } from "../../util/mocks";
 import { ElectionResultsSeats } from "./ElectionResultsSeats";
 
 export default {
-  title: "Election results seats visualisation",
+  title: "Election results / Seats visualisation",
   component: ElectionResultsSeats,
 };
 

--- a/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.stories.tsx
+++ b/src/components/ElectionResultsStackedBar/ElectionResultsStackedBar.stories.tsx
@@ -6,7 +6,7 @@ import { mockResults, mockMayorResults, mockMayorElectionMeta, mockNationalElect
 import { ElectionResultsStackedBar } from "./ElectionResultsStackedBar";
 
 export default {
-  title: "Election results stacked bar",
+  title: "Election results / Stacked bar",
   component: ElectionResultsStackedBar,
 };
 

--- a/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
+++ b/src/components/ElectionResultsSummarySection/ElectionResultsSummarySection.stories.tsx
@@ -20,7 +20,7 @@ import {
 import { ElectionResultsSummarySection } from "./ElectionResultsSummarySection";
 
 export default {
-  title: "Election results summary section",
+  title: "Election results / Summary section",
   component: ElectionResultsSummarySection,
 };
 

--- a/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.stories.tsx
+++ b/src/components/ElectionResultsSummaryTable/ElectionResultsSummaryTable.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { ElectionResultsSummaryTable } from "./ElectionResultsSummaryTable";
 
 export default {
-  title: "Election results summary table",
+  title: "Election results / Summary table",
   component: ElectionResultsSummaryTable,
 };
 

--- a/src/components/ElectionResultsTableSection/ElectionResultsTableSection.stories.tsx
+++ b/src/components/ElectionResultsTableSection/ElectionResultsTableSection.stories.tsx
@@ -12,7 +12,7 @@ import {
 import { ElectionResultsTableSection } from "./ElectionResultsTableSection";
 
 export default {
-  title: "Election results tables section",
+  title: "Election results / Tables section",
   component: ElectionResultsTableSection,
 };
 

--- a/src/components/ElectionScopePicker/ElectionScopePicker.stories.tsx
+++ b/src/components/ElectionScopePicker/ElectionScopePicker.stories.tsx
@@ -6,7 +6,7 @@ import { mockElectionAPI } from "../../util/mocks";
 import { ElectionScopePicker, useElectionScopePickerApi } from "./ElectionScopePicker";
 
 export default {
-  title: "Election scope picker",
+  title: "Election / Scope picker",
   component: ElectionScopePicker,
 };
 

--- a/src/components/ElectionTimeline/ElectionTimeline.stories.tsx
+++ b/src/components/ElectionTimeline/ElectionTimeline.stories.tsx
@@ -5,7 +5,7 @@ import { mockElectionList } from "../../util/mocks";
 import { ElectionTimeline } from "./ElectionTimeline";
 
 export default {
-  title: "Election timeline",
+  title: "Election / Timeline",
   component: ElectionTimeline,
 };
 

--- a/src/components/ElectionTurnoutBreakdownChart/ElectionTurnoutBreakdownChart.stories.tsx
+++ b/src/components/ElectionTurnoutBreakdownChart/ElectionTurnoutBreakdownChart.stories.tsx
@@ -5,7 +5,7 @@ import { mockPresidentialElectionTurnout } from "../../util/mocks";
 import { ElectionTurnoutBreakdownChart } from "./ElectionTurnoutBreakdownChart";
 
 export default {
-  title: "Election turnout breakdown chart",
+  title: "Election / Turnout breakdown chart",
   component: ElectionTurnoutBreakdownChart,
 };
 

--- a/src/components/ElectionTurnoutSection/ElectionTurnoutSection.stories.tsx
+++ b/src/components/ElectionTurnoutSection/ElectionTurnoutSection.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { ElectionTurnoutSection } from "./ElectionTurnoutSection";
 
 export default {
-  title: "Election turnout section",
+  title: "Election / Turnout section",
   component: ElectionTurnoutSection,
 };
 


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #XXX 

<!-- Please mention the main changes this PR brings. -->

It will group the components by Election / Election Results 
<img width="227" alt="Screenshot 2020-11-21 at 13 42 13" src="https://user-images.githubusercontent.com/6429818/99876430-581ecb00-2bff-11eb-8ee5-494be5dc7cf4.png">

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
