### PR TITLE
Pagination for Discreet table

### DIFF
--- a/src/components/ElectionResultsDiscreteTableSection/ElectionResultsDiscreteTableSection.tsx
+++ b/src/components/ElectionResultsDiscreteTableSection/ElectionResultsDiscreteTableSection.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useState } from "react";
+import React from "react";
 import { ResultsTable } from "../ResultsTable/ResultsTable";
 import { ElectionResultsCandidate } from "../../types/Election";
 import { formatGroupedNumber } from "../../util/format";
 import { themable } from "../../hooks/theme";
+import { usePagination } from "../../hooks/usePagination";
 import { Button } from "../Button/Button";
 import classes from "./ElectionResultsDiscreteTableSection.module.scss";
 
@@ -15,12 +16,9 @@ const CandidateTable: React.FC<{
   candidates: ElectionResultsCandidate[] | undefined;
   heading: string;
 }> = ({ candidates, heading }) => {
-  const [collapsed, setCollapsed] = useState<boolean>(true);
-  const canCollapse = candidates && candidates.length >= 12;
+  const candidatesCount = candidates?.length || 0;
+  const { limit, buttonText, canCollapse, onToggleCollapsed } = usePagination({ total: candidatesCount, size: 10 });
 
-  const onToggleCollapsed = useCallback(() => {
-    setCollapsed((x) => !x);
-  }, []);
   return (
     <div className={classes.tableContainer}>
       <ResultsTable className={classes.table}>
@@ -34,7 +32,7 @@ const CandidateTable: React.FC<{
           {candidates &&
             candidates.map(
               (candidate, index) =>
-                (!(canCollapse && collapsed) || index < 10) && (
+                (!(canCollapse && limit) || index < limit) && (
                   <tr key={index}>
                     <td className={classes.nameCell}>{candidate.name}</td>
                     <td>{formatGroupedNumber(candidate.votes)}</td>
@@ -45,7 +43,7 @@ const CandidateTable: React.FC<{
       </ResultsTable>
       {canCollapse && (
         <Button className={classes.collapseButton} onClick={onToggleCollapsed}>
-          {collapsed ? "Afișează toate rezultatele" : "Ascunde rezultatele"}
+          {buttonText}
         </Button>
       )}
     </div>

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+export type PaginationResponse = {
+  buttonText: string;
+  limit: number;
+  canCollapse: boolean;
+  onToggleCollapsed: () => unknown;
+};
+
+export type PaginationOptions = {
+  total: number;
+  size: number;
+};
+
+export function usePagination({ total, size }: PaginationOptions): PaginationResponse {
+  const [limit, setLimit] = useState<number>(size);
+
+  const onToggleCollapsed = useCallback(() => {
+    setLimit((currentLimit) => (currentLimit < total ? currentLimit + size : size));
+  }, []);
+
+  const showMoreText = "Afișează mai multe rezultate";
+  const showLessText = "Ascunde rezultatele";
+  const canCollapse = total > size;
+  const showMore = total > limit;
+  const buttonText = showMore ? showMoreText : showLessText;
+
+  return { buttonText, limit, canCollapse, onToggleCollapsed };
+}


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes https://github.com/code4romania/reusable-components/issues/91

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

Locally with [Storybook](http://localhost:6006/?path=/story/election-results-discrete-tables-section--simple-example)

When there are more than 10 rows in the table:
<img width="1408" alt="Screenshot 2020-11-28 at 12 58 43" src="https://user-images.githubusercontent.com/6429818/100513934-79d8fe80-3179-11eb-86c2-be211de655ea.png">

When all results are displayed:
<img width="1415" alt="Screenshot 2020-11-28 at 12 58 51" src="https://user-images.githubusercontent.com/6429818/100513932-78a7d180-3179-11eb-9416-337b567566e2.png">

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
